### PR TITLE
Added TagLib and switched MP3.cpp to use it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 *.nso
 *.npdm
 *.ovl
+.DS_Store
+._*
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "Common/libs/minIni/minIni"]
 	path = Common/libs/minIni/minIni
 	url = https://github.com/compuphase/minIni
+[submodule "Application/libs/taglib"]
+	path = Application/libs/taglib
+	url = https://github.com/taglib/taglib.git

--- a/Application/Makefile
+++ b/Application/Makefile
@@ -30,11 +30,12 @@ include $(DEVKITPRO)/libnx/switch_rules
 #---------------------------------------------------------------------------------
 TARGET		:=	TriPlayer
 BUILD		:=	build
-INCLUDES	:=	include ../Common/include ../Common/libs/minIni/minIni/dev ../Common/libs/splash/splash/include libs/avir libs/dtl/dtl
+TL_INCLUDES :=	$(shell find libs/taglib/taglib -type d)
+INCLUDES	:=	include ../Common/include ../Common/libs/minIni/minIni/dev ../Common/libs/splash/splash/include libs/avir libs/dtl/dtl $(TL_INCLUDES)
 SOURCES		:=	source	../Common/source
 ROMFS		:=	romfs
-LIBS		:=  -lAether -lcurl -lminIni -lmpg123 -lnx -lSQLite `sdl2-config --libs` -lSDL2_ttf `freetype-config --libs` -lSDL2_gfx -lSDL2_image -lSplash -lpng -ljpeg -lwebp -lzzip
-LIBDIRS		:=	$(PORTLIBS) $(LIBNX) $(CURDIR)/libs/Aether $(CURDIR)/libs/json $(CURDIR)/../Common/libs/minIni $(CURDIR)/../Common/libs/SQLite $(CURDIR)/../Common/libs/splash
+LIBS		:=  -lAether -ltag -lcurl -lminIni -lmpg123 -lnx -lSQLite `sdl2-config --libs` -lSDL2_ttf `freetype-config --libs` -lSDL2_gfx -lSDL2_image -lSplash -lpng -ljpeg -lwebp -lzzip
+LIBDIRS		:=	$(PORTLIBS) $(LIBNX) $(CURDIR)/libs/Aether $(CURDIR)/libs/taglib $(CURDIR)/libs/json $(CURDIR)/../Common/libs/minIni $(CURDIR)/../Common/libs/SQLite $(CURDIR)/../Common/libs/splash
 
 #---------------------------------------------------------------------------------
 # Options for .nacp information
@@ -118,9 +119,15 @@ libs:
 ifeq ($(wildcard $(CURDIR)/libs/Aether/LICENSE),)
 	@$(error "'libs/Aether' missing: Please run 'git submodule update --init!")
 endif
+ifeq ($(wildcard $(CURDIR)/libs/taglib/README.md),)
+	@$(error "'libs/taglib' missing: Please run 'git submodule update --init!")
+endif
 	@echo --- Compiling Aether ---
 	@$(MAKE) -s -C $(CURDIR)/libs/Aether -f $(CURDIR)/libs/Aether/Makefile
 	@echo --- Aether Compiled! ---
+	@echo --- Compiling TagLib ---
+	@$(MAKE) -s -C $(CURDIR)/libs/taglib -f $(CURDIR)/libs/taglib.mk
+	@echo --- TagLib Compiled! ---
 
 #----------------------------------------------------------------------------------------------------------------------
 # 'clean-all' removes ALL build files
@@ -129,6 +136,9 @@ clean-all: clean
 	@echo --- Cleaning Aether ---
 	@$(MAKE) --silent -C $(CURDIR)/libs/Aether -f $(CURDIR)/libs/Aether/Makefile clean
 	@echo --- Aether Cleaned! ---
+	@echo --- Cleaning TagLib ---
+	@$(MAKE) --silent -C $(CURDIR)/libs/taglib -f $(CURDIR)/libs/taglib.mk clean
+	@echo --- TagLib Cleaned! ---
 
 #----------------------------------------------------------------------------------------------------------------------
 # 'clean' removes ALL app build files (but not libraries)

--- a/Application/include/utils/MP3.hpp
+++ b/Application/include/utils/MP3.hpp
@@ -5,18 +5,12 @@
 #include <vector>
 
 namespace Utils::MP3 {
-    // Initializes libraries used for helper functions
-    // Returns false if an error occurred
-    bool init();
-
-    // Cleans up any initialized libraries
-    void exit();
-
-    // Reads image(s) from ID3 tags using mpg123 and returns SongArt
-    // data pointer will be nullptr and size 0 if none found
+    // Reads image(s) from ID3 tags using TagLib and returns a vector containing the image data 
+    // The vector will be size 0 if no art is found
+    // Pass path of file
     std::vector<unsigned char> getArtFromID3(std::string);
 
-    // Reads ID3 tags of file using mpg123 and returns SongInfo
+    // Reads ID3 tags of file using TagLib and returns SongInfo
     // ID is -1 on success (filled), -2 on success (song has no tags), -3 on failure
     // Pass path of file
     Metadata::Song getInfoFromID3(std::string);

--- a/Application/libs/taglib.mk
+++ b/Application/libs/taglib.mk
@@ -1,0 +1,117 @@
+# This Makefile builds the untouched upstream TagLib as a Switch/libnx
+# static library, since their CMake build config wasn't cooperating.
+# That's why this Makefile is located outside of the TagLib submodule.
+# It's written with as little as possible hard-coded so hopefully it
+# will continue to work even if they shuffle around the files later.
+
+#----------------------------------------------------------------------------------------------------------------------
+# Default target is 'all'
+#----------------------------------------------------------------------------------------------------------------------
+.DEFAULT_GOAL := all
+#----------------------------------------------------------------------------------------------------------------------
+
+#----------------------------------------------------------------------------------------------------------------------
+# Check if DEVKITPRO exists in current environment
+#----------------------------------------------------------------------------------------------------------------------
+ifndef DEVKITPRO
+$(error DEVKITPRO is not present in your environment. This can be fixed by sourcing switchvars.sh from /opt/devkitpro/)
+endif
+#----------------------------------------------------------------------------------------------------------------------
+
+#----------------------------------------------------------------------------------------------------------------------
+# Include switch build toolchain file
+#----------------------------------------------------------------------------------------------------------------------
+include $(DEVKITPRO)/libnx/switch_rules
+#----------------------------------------------------------------------------------------------------------------------
+
+#---------------------------------------------------------------------------------
+# Options for compilation
+# TARGET: Name of the output file(s)
+# BUILD: Directory where object files & intermediate files will be placed
+# INCLUDES: List of directories containing header files
+# SOURCES: List of directories containing source code
+# LIB: Output directory for archive
+# OUTPUT: Output file
+#---------------------------------------------------------------------------------
+TARGET		:=	Tag
+BUILD		:=	build
+INCLUDES 	:=	$(shell find taglib -type d)
+INCLUDE		:=	-I3rdparty $(addprefix -I,$(INCLUDES))
+SOURCE		:=	taglib
+LIB			:=	lib
+OUTPUT		:=	$(LIB)/lib$(TARGET).a
+
+#---------------------------------------------------------------------------------
+# Options for code generation
+#---------------------------------------------------------------------------------
+OBJDIR		:=	$(BUILD)/objs
+DEPDIR		:=	$(BUILD)/deps
+ARCH		:=	-march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
+ASFLAGS		:=	-g $(ARCH)
+LD			:=	$(CXX)
+LDFLAGS		:=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH)
+
+#---------------------------------------------------------------------------------
+# Flags to pass to compiler
+#---------------------------------------------------------------------------------
+CFLAGS		:=	-g -Wall -O2 -ffunction-sections $(ARCH) $(INCLUDE)
+# CXXFLAGS	:=	$(CFLAGS) -fno-rtti -std=gnu++17 -fno-exceptions
+# NOTE: This library requires both RTTI and exceptions. It should be possible to
+#       to remove that requirement if needed, but for now I've just removed the 
+#       compiler flags to allow it to build.
+CXXFLAGS	:=	$(CFLAGS) -std=gnu++17
+
+#----------------------------------------------------------------------------------------------------------------------
+# Definition of variables which store file locations
+#----------------------------------------------------------------------------------------------------------------------
+CPPFILES	:= $(shell find $(SOURCE)/ -name "*.cpp")
+OBJS		:= $(filter %.o, $(CPPFILES:$(SOURCE)/%.cpp=$(OBJDIR)/%.o))
+DEPS		:= $(filter %.d, $(CPPFILES:$(SOURCE)/%.cpp=$(DEPDIR)/%.d))
+TREE		:= $(sort $(patsubst %/,%,$(dir $(OBJS))))
+#----------------------------------------------------------------------------------------------------------------------
+
+#----------------------------------------------------------------------------------------------------------------------
+# Include dependent files if they already exist
+#----------------------------------------------------------------------------------------------------------------------
+ifeq "$(MAKECMDGOALS)" ""
+-include $(DEPS)
+endif
+#----------------------------------------------------------------------------------------------------------------------
+
+#----------------------------------------------------------------------------------------------------------------------
+# Define few virtual make targets
+#----------------------------------------------------------------------------------------------------------------------
+.PHONY: all clean
+#----------------------------------------------------------------------------------------------------------------------
+all: $(SOURCE)/taglib_config.h $(OUTPUT)
+
+$(SOURCE)/taglib_config.h:
+	@cp $(SOURCE)/taglib_config.h.cmake $(SOURCE)/taglib_config.h
+
+# Compiles each object file
+.SECONDEXPANSION:
+$(OBJDIR)/%.o: $(SOURCE)/%.cpp | $$(@D)
+	@echo Compiling $*.o...
+	@$(CXX) -MMD -MP -MF $(@:$(OBJDIR)/%.o=$(DEPDIR)/%.d) $(CXXFLAGS) -o $@ -c $<
+
+# Builds the library archive from all .o files
+$(OUTPUT): $(OBJS)
+	@[ -d $(LIB) ] || mkdir -p $(LIB)
+	@rm -rf $(OUTPUT)
+	@echo Creating $(TARGET) library archive at $(OUTPUT)...
+	@$(AR) -rc $(OUTPUT) $(OBJS)
+
+#----------------------------------------------------------------------------------------------------------------------
+# 'clean' removes ALL build files
+#----------------------------------------------------------------------------------------------------------------------
+clean:
+	@echo Cleaning TagLib build files...
+	@rm -f $(SOURCE)/taglib_config.h
+	@rm -rf $(BUILD) $(LIB)
+
+#----------------------------------------------------------------------------------------------------------------------
+# Define rule recipe `$(TREE)` (creates directories for .o and .d files)
+#----------------------------------------------------------------------------------------------------------------------
+$(TREE): %:
+	@mkdir -p $@
+	@mkdir -p $(@:$(OBJDIR)%=$(DEPDIR)%)

--- a/Application/source/Application.cpp
+++ b/Application/source/Application.cpp
@@ -26,7 +26,6 @@ namespace Main {
 
         // Start services
         Utils::Curl::init();
-        Utils::MP3::init();
 
         // Prepare theme
         this->theme_ = new Theme();
@@ -218,7 +217,6 @@ namespace Main {
         delete this->config_;
 
         // Stop services
-        Utils::MP3::exit();
         Utils::Curl::exit();
 
         // The database will be closed here as the wrapper goes out of scope

--- a/Application/source/utils/MP3.cpp
+++ b/Application/source/utils/MP3.cpp
@@ -19,12 +19,12 @@ namespace Utils::MP3 {
             // Read the ID3v2 tag
             // NOTE: ID3v1 does not support album art
             if (audioFile.hasID3v2Tag()) {
-                TagLib::ID3v2::Tag* tag = audioFile.ID3v2Tag();
+                TagLib::ID3v2::Tag * tag = audioFile.ID3v2Tag();
                 if (tag) {
                     // Extract the cover art tag frame
                     TagLib::ID3v2::FrameList coverFrameList = tag->frameListMap()["APIC"];
                     if (!coverFrameList.isEmpty()) {
-                        TagLib::ID3v2::AttachedPictureFrame* coverFrame = (TagLib::ID3v2::AttachedPictureFrame*)coverFrameList.front();
+                        TagLib::ID3v2::AttachedPictureFrame * coverFrame = (TagLib::ID3v2::AttachedPictureFrame *)coverFrameList.front();
                         if (coverFrame) {
                             // Check the image format and extract it if supported
                             TagLib::String mType = coverFrame->mimeType();
@@ -69,7 +69,7 @@ namespace Utils::MP3 {
         TagLib::MPEG::File audioFile(path.c_str(), true, TagLib::AudioProperties::Average);
         if (audioFile.isValid()) {
             // Read the audio properties to get the duration
-            TagLib::MPEG::Properties* audioProperties = audioFile.audioProperties();
+            TagLib::MPEG::Properties * audioProperties = audioFile.audioProperties();
             if (audioProperties) {
                 m.duration = (unsigned int)audioProperties->lengthInSeconds();
             } else {
@@ -78,7 +78,7 @@ namespace Utils::MP3 {
 
             // Confirm the tags exist and read them
             if (audioFile.hasID3v2Tag()) {
-                TagLib::ID3v2::Tag* tag = audioFile.ID3v2Tag();
+                TagLib::ID3v2::Tag * tag = audioFile.ID3v2Tag();
                 if (tag) {
                     m.ID = -1;
                     TagLib::String title = tag->title();
@@ -104,8 +104,9 @@ namespace Utils::MP3 {
                 }
             } else if (audioFile.hasID3v1Tag()) {
                 // NOTE: ID3v1 does not have a disc number tag
-                TagLib::ID3v1::Tag* tag = audioFile.ID3v1Tag();
+                TagLib::ID3v1::Tag * tag = audioFile.ID3v1Tag();
                 if (tag) {
+                    m.ID = -1;
                     TagLib::String title = tag->title();
                     if (!title.isEmpty()) m.title = title.to8Bit(true);
                     TagLib::String artist = tag->artist();

--- a/Application/source/utils/MP3.cpp
+++ b/Application/source/utils/MP3.cpp
@@ -1,373 +1,51 @@
-#include <cmath>
-#include <cstring>
 #include <filesystem>
-#include <fstream>
-#include <mpg123.h>
-#include <mutex>
 #include "Log.hpp"
 #include "utils/MP3.hpp"
 
-// Size of read buffer (used for calculating duration) - 20MB
-// This should be enough for most songs, but also large enough to not cause too many
-// reads for very large files
-#define READ_BUFFER_SIZE 20 * 1024 * 1024
-
-// Bitrates matching value of bitrate bits
-static const int bitVer1[16] = {0, 32000, 40000, 48000, 56000, 64000, 80000, 96000, 112000, 128000, 160000, 192000, 224000, 256000, 320000, 0};
-static const int bitVer2[16] = {0, 32000, 48000, 56000, 64000, 80000, 96000, 112000, 128000, 144000, 160000, 176000, 192000, 224000, 256000, 0};
-
-// MPEG Version
-enum class MPEGVer {
-    One,        // 1
-    Two,        // 2
-    TwoFive     // 2.5
-};
-
-// mpg123 instance
-static mpg123_handle * mpg = nullptr;
-
-// Mutex protecting above handle
-static std::mutex mutex;
+// TagLib
+#include <mpegfile.h>
+#include <id3v2tag.h>
+#include <id3v1tag.h>
+#include <attachedpictureframe.h>
 
 namespace Utils::MP3 {
-    // Small helper function which returns a string from a (possibly not) null terminated string
-    static std::string arrayToString(char * data, size_t size) {
-        // Ensure it's null terminated
-        char arr[size + 1];
-        std::memcpy(arr, data, size);
-        arr[size] = '\0';
-
-        return std::string(arr);
-    }
-
-    static std::string mpgStrToString(mpg123_string * str) {
-        if (str == nullptr) {
-            return "";
-        }
-
-        // mpg123_string can contain multiple strings - we only want the first one
-        size_t len = std::strlen(str->p);
-        return std::string(str->p, len);
-    }
-
-    // Calculates duration of MP3 file and returns in seconds (0 if error occurred)
-    // If you're reading this and you're interested how I came up with this,
-    // see this site: http://www.mp3-tech.org/programmer/frame_header.html
-    static unsigned int parseDuration(std::ifstream &file) {
-        double seconds = 0;
-
-        // Read buffer
-        unsigned char * buf = new unsigned char[READ_BUFFER_SIZE];
-        size_t size = 0;
-
-        // Position to begin reading from in next buffer
-        size_t beginAt = 0;
-
-        bool atStart = true;
-        bool atPadding = false;
-        while (file) {
-            // Read chunks of the file until we reach the end
-            file.read((char *) buf + size, READ_BUFFER_SIZE - size);
-            size += file.gcount();
-            if (!size) {
-                break;
-            }
-
-            // Byte we are 'at' in this buffer
-            size_t pos = beginAt;
-
-            // Check for the ID3 tag if at the start
-            if (atStart) {
-                // Stop if we didn't read 10 bytes
-                if (size < 10) {
-                    seconds = 0;
-                    break;
-                }
-
-                // If we have an ID3 tag skip it
-                if (buf[0] == 'I' && buf[1] == 'D' && buf[2] == '3') {
-                    unsigned int tagSize = 0;
-                    tagSize = ((buf[6] & 127) << 21) | ((buf[7] & 127) << 14) | ((buf[8] & 127) << 7) | ((buf[9] & 127));
-                    pos += 10 + tagSize;
-                }
-                atPadding = true;
-            }
-
-            // The ID3 specification permits 0x00 bytes as padding after
-            // the ID3 header/frames, so skip over those too
-            if (atPadding) {
-                // Loop until we either reach a frame or the end of the buffer
-                bool needMoreBytes = false;
-                while (buf[pos] == 0x00) {
-                    pos++;
-                    if (pos >= size) {
-                        needMoreBytes = true;
-                        break;
-                    }
-                }
-
-                // Get another buffer if we need to
-                if (needMoreBytes) {
-                    size = 0;
-                    beginAt = 0;
-                    continue;
-                }
-                atPadding = false;
-            }
-
-            // Loop over MPEG frames in the buffer until we run out
-            bool loop = true;
-            while (pos < size && size - pos >= 3) {
-                // Check for the header and stop once we encounter something that isn't right
-                if (!(buf[pos] == 0xFF && (buf[pos + 1] & 0b11100000) == 0b11100000)) {
-                    loop = false;
-                    break;
-                }
-
-                // Get mpeg version (layer is always 3!)
-                MPEGVer ver = MPEGVer::One;
-                switch ((buf[pos + 1] & 0b00011000) >> 3) {
-                    case 0b11:
-                        ver = MPEGVer::One;
-                        break;
-
-                    case 0b10:
-                        ver = MPEGVer::Two;
-                        break;
-
-                    case 0b00:
-                        ver = MPEGVer::TwoFive;
-                        break;
-                }
-
-                // Check for CRC bytes (not used)
-                // bool hasCRC = ((buf[pos + 1] & 0b1) == 0b0);
-
-                // Get bitrate
-                int bitrate;
-                switch (ver) {
-                    case MPEGVer::One:
-                        bitrate = bitVer1[(buf[pos + 2] & 0b11110000) >> 4];
-                        break;
-
-                    case MPEGVer::Two:
-                    case MPEGVer::TwoFive:
-                        bitrate = bitVer2[(buf[pos + 2] & 0b11110000) >> 4];
-                        break;
-                }
-
-                // Get sample rate
-                int samplerate = 1;
-                switch ((buf[pos + 2] & 0b00001100) >> 2) {
-                    case 0b00:
-                        samplerate = 44100;
-                        break;
-
-                    case 0b01:
-                        samplerate = 48000;
-                        break;
-
-                    case 0b10:
-                        samplerate = 32000;
-                        break;
-                }
-                if (ver == MPEGVer::Two) {
-                    samplerate /= 2;
-                } else if (ver == MPEGVer::TwoFive) {
-                    samplerate /= 4;
-                }
-
-                // Check for padding
-                bool hasPadding = (((buf[pos + 2] & 0b10) >> 1) == 0b1);
-
-                // Calculate size and jump to next frame header
-                unsigned int frameSize = ((144 * bitrate) / samplerate) + (hasPadding ? 1 : 0) - 4;
-                pos += (4 + frameSize);
-
-                // Duration in seconds is (samples per frame / sample rate)
-                seconds += (1152 / (long double)samplerate);
-            }
-
-            // Break immediately on error
-            if (!loop) {
-                break;
-            }
-
-            // Move remaining bytes to the start of the buffer
-            if (pos < size) {
-                size -= pos;
-                for (size_t i = 0; i < size; i++) {
-                    buf[i] = buf[pos + i];
-                }
-                beginAt = 0;
-
-            // Otherwise indicate what byte in the next buffer will start the next header
-            } else {
-                beginAt = (pos - size);
-                size = 0;
-            }
-            atStart = false;
-        }
-
-        delete[] buf;
-        return (unsigned int)std::round(seconds);
-    }
-
-    // Parses ID3v1 tags and fills Metadata struct
-    static void parseID3V1(mpg123_id3v1 * v1, Metadata::Song & info) {
-        info.title = arrayToString(v1->title, sizeof(v1->title));
-        info.artist = arrayToString(v1->artist, sizeof(v1->artist));
-        info.album = arrayToString(v1->album, sizeof(v1->album));
-    }
-
-    // Parses ID3v2 tags and fills Metadata struct
-    static void parseID3V2(mpg123_id3v2 * v2, Metadata::Song & info) {
-        std::string tmp;
-        if (v2->title != nullptr) {
-            tmp = mpgStrToString(v2->title);
-            if (tmp.length() > 0) {
-                info.title = tmp;
-            }
-        }
-        if (v2->artist != nullptr) {
-            tmp = mpgStrToString(v2->artist);
-            if (tmp.length() > 0) {
-                info.artist = tmp;
-            }
-        }
-        if (v2->album != nullptr) {
-            tmp = mpgStrToString(v2->album);
-            if (tmp.length() > 0) {
-                info.album = tmp;
-            }
-        }
-
-        // To find other metadata we need to iterate over each field
-        char done = 0x0;
-        for (size_t i = 0; i < v2->texts; i++) {
-            mpg123_text t = v2->text[i];
-
-            // Track number
-            if (t.id[0] == 'T' && t.id[1] == 'R' && t.id[2] == 'C' && t.id[3] == 'K') {
-                done |= 0x01;
-                errno = 0;
-                int tmp = std::atoi(t.text.p);
-                if (errno == 0) {
-                    info.trackNumber = tmp;
-                }
-                continue;
-            }
-
-            // Disc number
-            if (t.id[0] == 'T' && t.id[1] == 'P' && t.id[2] == 'O' && t.id[3] == 'S') {
-                done |= 0x10;
-                errno = 0;
-                int tmp = std::atoi(t.text.p);
-                if (errno == 0) {
-                    info.discNumber = tmp;
-                }
-                continue;
-            }
-
-            // Stop when all are found
-            if (done == 0x11) {
-                break;
-            }
-        }
-    }
-
-    bool init() {
-        // Prepare library
-        int err = mpg123_init();
-        if (err != MPG123_OK) {
-            Log::writeError("[MP3] Failed to init mpg123");
-            return false;
-        }
-
-        // Create instance
-        mpg = mpg123_new(nullptr, &err);
-        if (err != MPG123_OK) {
-            Log::writeError("[MP3] Failed to create a mpg123 instance");
-            mpg = nullptr;
-            return false;
-        }
-
-        // Store pictures
-        err = mpg123_param(mpg, MPG123_ADD_FLAGS, MPG123_PICTURE, 0.0);
-        if (err != MPG123_OK) {
-            Log::writeError("[MP3] Failed to set MPG123_PICTURE flag");
-            return false;
-        }
-
-        Log::writeSuccess("[MP3] mpg123 initialized sucessfully!");
-        return true;
-    }
-
-    void exit() {
-        if (mpg != nullptr) {
-            mpg123_delete(mpg);
-        }
-        mpg = nullptr;
-    }
-
     // Searches and returns an appropriate image
     std::vector<unsigned char> getArtFromID3(std::string path) {
         std::vector<unsigned char> v;
 
-        // Use mpg123 to find images
-        std::scoped_lock<std::mutex> mtx(mutex);
-        if (mpg != nullptr) {
-            int err = mpg123_open(mpg, path.c_str());
-            if (err == MPG123_OK) {
-                // Check if there are ID3 tags
-                mpg123_seek(mpg, 0, SEEK_SET);
-                if (mpg123_meta_check(mpg) & MPG123_ID3) {
-                    // Structures storing metadata (v1 not used)
-                    mpg123_id3v1 * v1;
-                    mpg123_id3v2 * v2;
-
-                    // Parse metadata
-                    err = mpg123_id3(mpg, &v1, &v2);
-                    if (err == MPG123_OK) {
-                        // Check for ID3v2 tags
-                        if (v2 != nullptr) {
-                            // Iterate over all images to find a fitting image
-                            for (size_t i = 0; i < v2->pictures; i++) {
-                                mpg123_picture * pic = &v2->picture[i];
-                                std::string mType = mpgStrToString(&(pic->mime_type));
-
-                                // Need matching type and mime type
-                                if (pic->type == mpg123_id3_pic_other || pic->type == mpg123_id3_pic_front_cover) {
-                                    if (mType == "image/jpg" || mType == "image/jpeg" || mType == "image/png") {
-                                        // Copy image into vector
-                                        for (size_t i = 0; i < pic->size; i++) {
-                                            v.push_back(*(pic->data + i));
-                                        }
-                                        break;
-                                    }
-                                }
-                            }
-
-                            // Log if none found
-                            if (v.empty()) {
+        // Open the file to read the metadata
+        TagLib::MPEG::File audioFile(path.c_str(), false);
+        if (audioFile.isValid()) {
+            // Read the ID3v2 tag
+            // NOTE: ID3v1 does not support album art
+            if (audioFile.hasID3v2Tag()) {
+                TagLib::ID3v2::Tag* tag = audioFile.ID3v2Tag();
+                if (tag) {
+                    // Extract the cover art tag frame
+                    TagLib::ID3v2::FrameList coverFrameList = tag->frameListMap()["APIC"];
+                    if (!coverFrameList.isEmpty()) {
+                        TagLib::ID3v2::AttachedPictureFrame* coverFrame = (TagLib::ID3v2::AttachedPictureFrame*)coverFrameList.front();
+                        if (coverFrame) {
+                            // Check the image format and extract it if supported
+                            TagLib::String mType = coverFrame->mimeType();
+                            if (mType == "image/jpg" || mType == "image/jpeg" || mType == "image/png") {
+                                TagLib::ByteVector byteVector = coverFrame->picture();
+                                v.assign(byteVector.begin(), byteVector.end());
+                            } else {
                                 Log::writeInfo("[MP3] No suitable art found in: " + path);
                             }
-
                         } else {
-                            Log::writeWarning("[MP3] No ID3v2 tags were found in: " + path);
+                            Log::writeInfo("[MP3] No suitable art found in: " + path);
                         }
-
                     } else {
-                        Log::writeError("[MP3] Failed to parse metadata for: " + path);
+                        Log::writeInfo("[MP3] No suitable art found in: " + path);
                     }
                 } else {
                     Log::writeError("[MP3] Failed to parse metadata for: " + path);
                 }
-                // Free memory used by metadata
-                mpg123_meta_free(mpg);
+            } else {
+                Log::writeWarning("[MP3] No ID3v2 tags were found in: " + path);
             }
-            // Close file
-            mpg123_close(mpg);
         } else {
             Log::writeError("[MP3] Unable to open file: " + path);
         }
@@ -375,7 +53,7 @@ namespace Utils::MP3 {
         return v;
     }
 
-    // Checks for tag type and calls appropriate function
+    // Checks for tag type and reads the metadata
     Metadata::Song getInfoFromID3(std::string path) {
         // Default info to return
         Metadata::Song m;
@@ -385,62 +63,67 @@ namespace Utils::MP3 {
         m.album = "Unknown Album";                         // Same for album
         m.trackNumber = 0;                                 // Initially 0 to indicate not set
         m.discNumber = 0;                                  // Initially 0 to indicate not set
+        m.duration = 0;                                    // Initially 0 to indicate not set
 
-        // Use mpg123 to read ID3 tags
-        std::unique_lock<std::mutex> mtx(mutex);
-        if (mpg != nullptr) {
-            int err = mpg123_open(mpg, path.c_str());
-            if (err == MPG123_OK) {
-                // Check if there are ID3 tags
-                mpg123_seek(mpg, 0, SEEK_SET);
-                if (mpg123_meta_check(mpg) & MPG123_ID3) {
-                    // Structures storing metadata
-                    mpg123_id3v1 * v1;
-                    mpg123_id3v2 * v2;
+        // Open the file to read the tags
+        TagLib::MPEG::File audioFile(path.c_str(), true, TagLib::AudioProperties::Average);
+        if (audioFile.isValid()) {
+            // Read the audio properties to get the duration
+            TagLib::MPEG::Properties* audioProperties = audioFile.audioProperties();
+            if (audioProperties) {
+                m.duration = (unsigned int)audioProperties->lengthInSeconds();
+            } else {
+                Log::writeError("[MP3] Failed to read audio properties of file: " + path);
+            }
 
-                    // Parse metadata
-                    err = mpg123_id3(mpg, &v1, &v2);
-                    if (err == MPG123_OK) {
-                        // Check for ID3v2 tags first
-                        if (v2 != nullptr) {
-                            m.ID = -1;
-                            parseID3V2(v2, m);
-
-                        } else if (v1 != nullptr) {
-                            m.ID = -1;
-                            parseID3V1(v1, m);
-
-                        } else {
-                            // No tags found!
-                            m.ID = -2;
-                            Log::writeWarning("[MP3] No tags were found in: " + path);
+            // Confirm the tags exist and read them
+            if (audioFile.hasID3v2Tag()) {
+                TagLib::ID3v2::Tag* tag = audioFile.ID3v2Tag();
+                if (tag) {
+                    m.ID = -1;
+                    TagLib::String title = tag->title();
+                    if (!title.isEmpty()) m.title = title.to8Bit(true);
+                    TagLib::String artist = tag->artist();
+                    if (!artist.isEmpty()) m.artist = artist.to8Bit(true);
+                    TagLib::String album = tag->album();
+                    if (!album.isEmpty()) m.album = album.to8Bit(true);
+                    m.trackNumber = tag->track();
+                    TagLib::ID3v2::FrameListMap frameListMap = tag->frameListMap();
+                    TagLib::ID3v2::FrameList discNumberList = frameListMap["TPOS"];
+                    if (!discNumberList.isEmpty()) {
+                        TagLib::String discNumber = discNumberList.front()->toString();
+                        if (!discNumber.isEmpty()) {
+                            // NOTE: This correctly handles cases where the format is "1/2" rather than "1". 
+                            //       In both cases, it will return 1.
+                            m.discNumber = discNumber.toInt();
                         }
-
-                    } else {
-                        Log::writeError("[MP3] Failed to parse metadata for: " + path);
                     }
-                    // Free memory used by metadata
-                    mpg123_meta_free(mpg);
-
                 } else {
                     m.ID = -2;
-                    Log::writeWarning("[MP3] No ID3 metadata present in: " + path);
+                    Log::writeWarning("[MP3] No tags were found in: " + path);
                 }
-
-                // Close file
-                mpg123_close(mpg);
-
+            } else if (audioFile.hasID3v1Tag()) {
+                // NOTE: ID3v1 does not have a disc number tag
+                TagLib::ID3v1::Tag* tag = audioFile.ID3v1Tag();
+                if (tag) {
+                    TagLib::String title = tag->title();
+                    if (!title.isEmpty()) m.title = title.to8Bit(true);
+                    TagLib::String artist = tag->artist();
+                    if (!artist.isEmpty()) m.artist = artist.to8Bit(true);
+                    TagLib::String album = tag->album();
+                    if (!album.isEmpty()) m.album = album.to8Bit(true);
+                    m.trackNumber = tag->track();
+                } else {
+                    m.ID = -2;
+                    Log::writeWarning("[MP3] No tags were found in: " + path);
+                }
             } else {
-                Log::writeError("[MP3] Unable to open file: " + path);
+                m.ID = -2;
+                Log::writeWarning("[MP3] No ID3 metadata present in: " + path);
             }
+        } else {
+            Log::writeError("[MP3] Unable to open file: " + path);
         }
-        mtx.unlock();
-
-        // Calculate duration
-        std::ifstream file;
-        file.open(path, std::ios::binary | std::ios::in);
-        file.seekg(0, file.beg);
-        m.duration = parseDuration(file);
 
         return m;
     }


### PR DESCRIPTION
Created a custom Makefile at Application/libs/taglib.mk to allow building of untouched upstream TagLib as a Switch/libnx compatible static library as their CMake build config was not cooperating.

TagLib supports basically every audio file format we could possibly want to support, and also provides easy access to a bunch of additional metadata that TriPlayer currently isn't using, but may be interested in using in the future (bitrate, custom tags, etc).

I've tested this extensively on my Switch, so it should be ready to merge, but please confirm I didn't make any stupid C++ mistakes as I don't do much coding in C++ and may have missed something obvious.