### PR TITLE
Add sxos folder support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ all:
 	@touch sdcard/atmosphere/contents/4200000000000FFF/flags/boot2.flag
 	@cp Sysmodule/sys-triplayer.nsp sdcard/atmosphere/contents/4200000000000FFF/exefs.nsp
 
+	@mkdir -p sdcard/sxos/titles/4200000000000FFF/flags
+	@touch sdcard/sxos/titles/4200000000000FFF/flags/boot2.flag
+	@cp Sysmodule/sys-triplayer.nsp sdcard/sxos/titles/4200000000000FFF/exefs.nsp
+
 	@echo -e '\033[1m>> Done! Copy ./sdcard to the root of your SD Card :)\033[0m'
 
 clean:


### PR DESCRIPTION
sxos use sxos/titles/code/  not atmosphere/contents/code1233456/
I think if you want to  realize compatible .then need to add the code ，Otherwise, sxos user need to create the floder (sxos/titles/code123456/) just like me. It took me a while to solve this problem.

And in sxos it have good running ! ..for now  (3.05, 10.03) test pass.

If you know the mechanism ,and do not want to create the folder you can ignore this PR 😊,and close it 
or you can merge it . cheer~~