### PR TITLE
Adding Missing Text

### DIFF
--- a/Application/romfs/lang/en.json
+++ b/Application/romfs/lang/en.json
@@ -16,7 +16,8 @@
             "DownloadNoImage": "'$[1]' was found on TheAudioDB but has no image associated with it.",
             "Heading": "Artist Information",
             "Image": "Image",
-            "Name": "Name"
+            "Name": "Name",
+            "Searching": "Searching for '$[1]' on TheAudioDB.com..."            
         },
         "NotFound": "No artists found!",
         "PlayAlbum": "Play Album",


### PR DESCRIPTION
That's what I wanted to talk to you about. If you don't add the missing text to example.json, then other translators can not to fully translate it.